### PR TITLE
Change cookieconsent url

### DIFF
--- a/resources/views/container.blade.php
+++ b/resources/views/container.blade.php
@@ -3,5 +3,5 @@
     window.cookieconsent_options = {"message": "{{ $message }}", "dismiss": "{{ $dismiss }}", "learnMore": "{{ $learnMore }}", "link": "{{ $link }}", "theme": "{{ $theme  }}"};
 </script>
 
-<script type="text/javascript" src="//s3.amazonaws.com/cc.silktide.com/cookieconsent.latest.min.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.10/cookieconsent.min.js"></script>
 <!-- End Cookie Consent plugin -->


### PR DESCRIPTION
Fixes #0 (I was too lazy to create one)

## Changes proposed in this pull request:
- Change CookieConsent URL from amazonaws to cdnjs, because amazonaws gives 403 Error